### PR TITLE
Fix clicking on username links for bsky.social usernames

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -78,12 +78,6 @@ export const fetchProfile = function fetchProfile(
         }
 
         if (AppBskyActorProfile.isRecord(value)) {
-          const host = '.' + new URL(service).host
-
-          if (handle.endsWith(host)) {
-            handle = handle.slice(0, -host.length)
-          }
-
           onSuccess({ uri, handle, profile: value })
           return { uri, value }
         } else {


### PR DESCRIPTION
Bluesky doesn't support handles which arent url's so i removed the trimming
